### PR TITLE
Use LocalPath and refine folder name validation

### DIFF
--- a/src/Gml.Launcher/Views/Pages/SettingsPageView.axaml.cs
+++ b/src/Gml.Launcher/Views/Pages/SettingsPageView.axaml.cs
@@ -50,9 +50,9 @@ public partial class SettingsPageView : ReactiveUserControl<SettingsPageViewMode
 
                 if (folders.Count != 1) return;
 
-                var path = folders[0].Path.AbsolutePath;
+                var path = folders[0].Path.LocalPath;
 
-                if (path.Any(c => !char.IsLetter(c) || !char.IsLower(c) || c > 'z'))
+                if (path.Any(char.IsWhiteSpace))
                 {
                     throw new Exception("Invalid folder name");
                 }


### PR DESCRIPTION
Changed the usage from AbsolutePath to LocalPath for folder paths to ensure compatibility with local file paths. Improved folder name validation by checking for whitespace instead of checking for uppercase letters or non-letter characters.