### PR TITLE
Refactor OS architecture detection to use RuntimeInformation API.

### DIFF
--- a/src/Gml.Launcher/ViewModels/Pages/OverviewPageViewModel.cs
+++ b/src/Gml.Launcher/ViewModels/Pages/OverviewPageViewModel.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reactive.Concurrency;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -281,13 +282,15 @@ public class OverviewPageViewModel : PageViewModelBase
 
         var settings = await _storageService.GetAsync<SettingsInfo>(StorageConstants.Settings) ?? SettingsInfo.Default;
 
+        var osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLower().Replace("x", "");
+
         var localProfile = new ProfileCreateInfoDto
         {
             ProfileName = ListViewModel.SelectedProfile!.Name,
             RamSize = Convert.ToInt32(settings.RamValue),
             IsFullScreen = settings.FullScreen,
             OsType = ((int)_systemService.GetOsType()).ToString(),
-            OsArchitecture = Environment.Is64BitOperatingSystem ? "64" : "32",
+            OsArchitecture = osArchitecture,
             UserAccessToken = User.AccessToken,
             UserName = User.Name,
             UserUuid = User.Uuid,


### PR DESCRIPTION
В текущей реализации не передаётся полное название архитектуры. 
Под запуском на macOS с M процессорами это может привести к запуску Java через Rosetta, ибо будет скачана Java для x64 (Intel), а не именно под arm64.

Предлагаю для полного определения архитектуры использовать `RuntimeInformation.OSArchitecture`. Он может возвращать:
- X86
- X64
- Arm
- Arm64

В предложенном исправлении я преобразую строку в нижний регистр, убираю "x" — так из "X64" — мы получаем "64", из "Arm64" — "arm64". Это не должно сломать загрузку под другими системами.

Проверил на macOS/arm64 и windows/64