### PR TITLE
Add dynamic min value and tick frequency for RAM slider.

### DIFF
--- a/src/Gml.Launcher/ViewModels/Pages/SettingsPageViewModel.cs
+++ b/src/Gml.Launcher/ViewModels/Pages/SettingsPageViewModel.cs
@@ -68,6 +68,9 @@ public class SettingsPageViewModel : PageViewModelBase
         AvailableLanguages = new ObservableCollection<Language>(systemService.GetAvailableLanguages());
 
         MaxRamValue = systemService.GetMaxRam();
+        const int highRamThreshold = 16384;
+        MinRamValue = (ulong)(MaxRamValue > highRamThreshold ? 1024 : 512);
+        RamTickValue = (ulong)(MaxRamValue > highRamThreshold ? 1024 : 512);
 
         InstallationFolder = _gmlManager.InstallationDirectory;
 
@@ -78,7 +81,11 @@ public class SettingsPageViewModel : PageViewModelBase
 
     [Reactive] public bool FullScreen { get; set; }
 
+    [Reactive] public ulong MinRamValue { get; set; }
+
     [Reactive] public ulong MaxRamValue { get; set; }
+
+    [Reactive] public ulong RamTickValue { get; set; }
 
     [Reactive] public Language? SelectedLanguage { get; set; }
 

--- a/src/Gml.Launcher/Views/Pages/SettingsPageView.axaml
+++ b/src/Gml.Launcher/Views/Pages/SettingsPageView.axaml
@@ -62,9 +62,11 @@
                             IsVisible="{Binding DynamicRamValue, Converter={converters:BoolReverseConverter}}" />
 
                     <StackPanel IsVisible="{Binding DynamicRamValue, Converter={converters:BoolReverseConverter}}">
-                        <Slider Minimum="512"
+                        <Slider Minimum="{Binding MinRamValue}"
                                 Maximum="{Binding MaxRamValue}"
                                 Value="{Binding RamValue}"
+                                TickFrequency="{Binding RamTickValue}"
+                                IsSnapToTickEnabled="True"
                                 x:Name="ViewSlider"
                                 Classes="FormSlider" />
 


### PR DESCRIPTION
Предлагаю ползунку ОЗУ добавить шаги и повысить мин значение на системах с большим объёмом ОЗУ.

В предложенной реализации поставил порог на повышение в 16ГБ. До порога: мин. значение 512, шаг 512, если ОЗУ в системе превышает порог, то мин. значение 1 ГБ, шаг 1 ГБ.

<details><summary>Preview</summary>

![CleanShot 2025-01-05 at 04 02 55](https://github.com/user-attachments/assets/f84043aa-f6be-4b7f-b4cf-f02ced2dae75)

</details> 
